### PR TITLE
minor README.md fix (component -> device)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ PathName: "/home/gcc_user/upload/*.txt"
 BucketName: <put-you-bucket-name-here>
 Interval: 10
 ```
-Log into the component and create a text file in the /home/gcc_user/upload folder: 
+Log into the device and create a text file in the /home/gcc_user/upload folder: 
 ```
 echo test1.txt > /home/gcc_user/upload
 ```


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Minor clarification in `README.md` (component -> device), specifying that it is the device which the component is deployed to (not the component itself) which is logged in to.

Mandatory license notice:
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

@cyril-lagrange please review this change.
