### PR TITLE
fix: DirectoryUploader - interval is always 1 regardless of settings

### DIFF
--- a/src/DirectoryUploader.py
+++ b/src/DirectoryUploader.py
@@ -57,7 +57,7 @@ class DirectoryUploader:
         if(self.__client == None):
             self.__client = StreamManagerClient() 
         self.__logger = logger
-        self.__status_interval = min(interval,1)
+        self.__status_interval = max(interval,1)
         self.__filesProcessed = set()
         self.__interval=interval
 


### PR DESCRIPTION
Issue #, if available: -

Description of changes:
If `min(interval,1)` is used, the interval in the recipe setting does not have an effect. Should work fine with `max(interval,1)`

Mandatory license notice:
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

@cyril-lagrange please review this change.
